### PR TITLE
Exclude lib/Modelica from GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.mo linguist-language=Modelica
+lib/Modelica/** linguist-vendored


### PR DESCRIPTION
Mark `lib/Modelica` as vendored via `.gitattributes` so the bundled Modelica Standard Library no longer dominates the language breakdown on the GitHub repository page. The directory remains in the repo and is unchanged otherwise; only linguist's classification is affected.